### PR TITLE
Add parser for bif strings to probability tables and dag edges

### DIFF
--- a/brent/common.py
+++ b/brent/common.py
@@ -176,3 +176,79 @@ def is_path_blocked(path_list):
                 logging.info("found blocking node, can skip path")
                 return True
     return False
+
+
+def join_independent(this_df: pd.DataFrame, that_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Merges two probability dataframes assuming independent nodes
+
+    ## Example:
+
+    ```
+    >>> this_df = pd.DataFrame({'A': ['true', 'false'], 'prob': [0.5, 0.5]})
+    >>> that_df = pd.DataFrame({'B': ['true', 'false'], 'prob': [0.5, 0.5]})
+    >>> join_independent(this_df, that_df) # doctest: +NORMALIZE_WHITESPACE
+           A      B  prob
+    0   true   true  0.25
+    1   true  false  0.25
+    2  false   true  0.25
+    3  false  false  0.25
+    ```
+    """
+    if 'prob' not in this_df.columns:
+        raise ValueError('this_df should contain a `prob` column containing probabilities')
+    if 'prob' not in that_df.columns:
+        raise ValueError('that_df should contain a `prob` column containing probabilities')
+
+    return (this_df.assign(key=1)
+            .merge(that_df.assign(key=1), on='key')
+            .drop('key', 1)
+            .assign(prob=lambda d: d.prob_x * d.prob_y)
+            .drop(columns=['prob_x', 'prob_y'])
+            )
+
+
+def join_dependent(this_df: pd.DataFrame, that_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Merges two probability dataframes assuming dependencies between nodes by using that_df's indexes as conditionals.
+
+    If `this_df` denotes `p(A)` in table form and `that_df` denotes `p(B|A)` in table form
+    then the output of this function will denote `p(A, B)`.
+
+    `that_df` should have two columns `B` and `prob` and its index should be set to `A`'s values.
+
+    ## Example:
+
+    ```
+    >>> this_df = pd.DataFrame({'A': ['true', 'false'], 'prob': [0.5, 0.5]})
+    >>> that_df = pd.DataFrame({
+    ... 'A': ['true', 'false', 'true', 'false'],
+    ... 'B': ['true', 'true', 'false', 'false'],
+    ... 'prob': [0.3, 0.7, 0.8, 0.2]}).set_index('A')
+    >>> join_dependent(this_df, that_df) # doctest: +NORMALIZE_WHITESPACE
+           A      B  prob
+    0   true   true  0.15
+    0   true  false  0.40
+    1  false   true  0.35
+    1  false  false  0.10
+    ```
+    """
+    if 'prob' not in this_df.columns:
+        raise ValueError('this_df should contain a `prob` column containing probabilities')
+    if 'prob' not in that_df.columns:
+        raise ValueError('that_df should contain a `prob` column containing probabilities')
+
+    missing_names = [name for name in that_df.index.names if name not in this_df.columns]
+    if len(missing_names) > 0:
+        raise ValueError('missing_names are set as indexes to `that_df` but are not present in `this_df`')
+
+    if len(that_df.columns) > 2:
+        raise ValueError('`that_df` has more than two columns, perhaps you forgot to set the variables that '
+                         'are to be conditioned on as the index of the dataframe')
+
+    return (this_df
+            .merge(that_df, left_on=that_df.index.names, right_index=True)
+            .assign(prob=lambda d: d.prob_x * d.prob_y)
+            .drop(columns=['prob_x', 'prob_y'])
+            .reset_index(drop=True)
+            )

--- a/brent/parsers/__init__.py
+++ b/brent/parsers/__init__.py
@@ -1,0 +1,3 @@
+from .bif import bif
+
+__all__ = ['bif']

--- a/brent/parsers/bif.py
+++ b/brent/parsers/bif.py
@@ -20,7 +20,9 @@ def join_independent(this_df: pd.DataFrame, that_df: pd.DataFrame) -> pd.DataFra
     """
     Merges two probability dataframes assuming independent nodes
 
-    Example:
+    ## Example:
+
+    ```
     >>> this_df = pd.DataFrame({'A': ['true', 'false'], 'prob': [0.5, 0.5]})
     >>> that_df = pd.DataFrame({'B': ['true', 'false'], 'prob': [0.5, 0.5]})
     >>> join_independent(this_df, that_df) # doctest: +NORMALIZE_WHITESPACE
@@ -29,6 +31,7 @@ def join_independent(this_df: pd.DataFrame, that_df: pd.DataFrame) -> pd.DataFra
     1   true  false  0.25
     2  false   true  0.25
     3  false  false  0.25
+    ```
     """
     if 'prob' not in this_df.columns:
         raise ValueError('this_df should contain a `prob` column containing probabilities')
@@ -52,7 +55,9 @@ def join_dependent(this_df: pd.DataFrame, that_df: pd.DataFrame) -> pd.DataFrame
 
     `that_df` should have two columns `B` and `prob` and its index should be set to `A`'s values.
 
-    Example:
+    ## Example:
+
+    ```
     >>> this_df = pd.DataFrame({'A': ['true', 'false'], 'prob': [0.5, 0.5]})
     >>> that_df = pd.DataFrame({
     ... 'A': ['true', 'false', 'true', 'false'],
@@ -64,7 +69,7 @@ def join_dependent(this_df: pd.DataFrame, that_df: pd.DataFrame) -> pd.DataFrame
     0   true  false  0.40
     1  false   true  0.35
     1  false  false  0.10
-
+    ```
     """
     if 'prob' not in this_df.columns:
         raise ValueError('this_df should contain a `prob` column containing probabilities')

--- a/brent/parsers/bif.py
+++ b/brent/parsers/bif.py
@@ -1,0 +1,168 @@
+import re
+import logging
+from typing import Tuple, List, Iterator
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+PARSER_PATTERNS = {
+    'network': r'network (?P<networktype>\w+) {',
+    'variable': r"(variable (?P<varname>\w+) {\s+type (?P<vartype>\w+) \[ \d+ \] \{ (?P<states>[^}]*)\}\;)",
+    'uncond_probability': r"probability \( (?P<varname>\w+) \) \{\s+table (?P<probtable>[^;]*)",
+    'cond_probability': r"probability \( (?P<varname>\w+) \| (?P<conditionals>[^)]*) \) {\s (?P<probs>[^\}]*)",
+    'prob_table': r"^(\s+)? \((?P<keys>.*?)\) (?P<probabilities>[^;]*);",
+}
+
+
+def join_independent(this_df: pd.DataFrame, that_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Merges two probability dataframes assuming independent nodes
+
+    Example:
+    >>> this_df = pd.DataFrame({'A': ['true', 'false'], 'prob': [0.5, 0.5]})
+    >>> that_df = pd.DataFrame({'B': ['true', 'false'], 'prob': [0.5, 0.5]})
+    >>> join_independent(this_df, that_df) # doctest: +NORMALIZE_WHITESPACE
+           A      B  prob
+    0   true   true  0.25
+    1   true  false  0.25
+    2  false   true  0.25
+    3  false  false  0.25
+    """
+    if 'prob' not in this_df.columns:
+        raise ValueError('this_df should contain a `prob` column containing probabilities')
+    if 'prob' not in that_df.columns:
+        raise ValueError('that_df should contain a `prob` column containing probabilities')
+
+    return (this_df.assign(key=1)
+            .merge(that_df.assign(key=1), on='key')
+            .drop('key', 1)
+            .assign(prob=lambda d: d.prob_x * d.prob_y)
+            .drop(columns=['prob_x', 'prob_y'])
+            )
+
+
+def join_dependent(this_df: pd.DataFrame, that_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Merges two probability dataframes assuming dependencies between nodes by using that_df's indexes as conditionals.
+
+    If `this_df` denotes `p(A)` in table form and `that_df` denotes `p(B|A)` in table form
+    then the output of this function will denote `p(A, B)`.
+
+    `that_df` should have two columns `B` and `prob` and its index should be set to `A`'s values.
+
+    Example:
+    >>> this_df = pd.DataFrame({'A': ['true', 'false'], 'prob': [0.5, 0.5]})
+    >>> that_df = pd.DataFrame({
+    ... 'A': ['true', 'false', 'true', 'false'],
+    ... 'B': ['true', 'true', 'false', 'false'],
+    ... 'prob': [0.3, 0.7, 0.8, 0.2]}).set_index('A')
+    >>> join_dependent(this_df, that_df) # doctest: +NORMALIZE_WHITESPACE
+           A      B  prob
+    0   true   true  0.15
+    0   true  false  0.40
+    1  false   true  0.35
+    1  false  false  0.10
+
+    """
+    if 'prob' not in this_df.columns:
+        raise ValueError('this_df should contain a `prob` column containing probabilities')
+    if 'prob' not in that_df.columns:
+        raise ValueError('that_df should contain a `prob` column containing probabilities')
+
+    missing_names = [name for name in that_df.index.names if name not in this_df.columns]
+    if len(missing_names) > 0:
+        raise ValueError('missing_names are set as indexes to `that_df` but are not present in `this_df`')
+
+    if len(that_df.columns) > 2:
+        raise ValueError('`that_df` has more than two columns, perhaps you forgot to set the variables that '
+                         'are to be conditioned on as the index of the dataframe')
+
+    return (this_df
+            .merge(that_df, left_on=that_df.index.names, right_index=True)
+            .assign(prob=lambda d: d.prob_x * d.prob_y)
+            .drop(columns=['prob_x', 'prob_y'])
+            .reset_index(drop=True)
+            )
+
+
+def parse_network_type(bif: str) -> str:
+    """Returns the network type of a bif string"""
+    return re.match(PARSER_PATTERNS['network'], bif).group('networktype')
+
+
+def parse_variables(bif: str) -> Iterator[Tuple[str, List[str]]]:
+    """Returns a generator of `(varname, states)` tuples from a bif string"""
+    for var in re.finditer(PARSER_PATTERNS['variable'], bif):
+        varname = var.group('varname')
+        vartype = var.group('vartype')
+        states = var.group('states').strip().split(', ')
+
+        logger.info(f'Found variable: {varname} with states {states}')
+        if vartype != 'discrete':
+            raise ValueError('Brent only supports discrete variables')
+
+        yield varname, states
+
+
+def parse_unconditional_probabilities(bif: str) -> Iterator[Tuple[str, List[float]]]:
+    """Parses unconditional probabilities from a bif string"""
+    for prob in re.finditer(PARSER_PATTERNS['uncond_probability'], bif):
+        varname = prob.group('varname')
+        probs = [float(p) for p in prob.group('probtable').split(', ')]
+
+        logger.info(f'Found base probability for variable {varname}: {probs}')
+        if 1 - sum(probs) > 0.01:
+            logger.warning(f'Variable {varname} has probabilities not summing to 1 (sums to {sum(probs)})')
+
+        yield varname, probs
+
+
+def parse_conditional_probabilities(bif: str):
+    """parses conditional probabilities from a bif string"""
+    for cond_prob in re.finditer(PARSER_PATTERNS['cond_probability'], bif):
+        varname, prob_table = cond_prob.group('varname'), cond_prob.group('probs')
+        conditionals = cond_prob.group('conditionals').split(', ')
+        logger.info(f'Found conditional probability: {varname} | {conditionals}')
+
+        probabilities_lst = []
+
+        for line_no, prob_entry in enumerate(re.finditer(PARSER_PATTERNS['prob_table'], prob_table, re.MULTILINE)):
+            keys = prob_entry.group('keys').split(', ')
+            probabilities = [float(p) for p in prob_entry.group('probabilities').split(', ')]
+            if 1 - sum(probabilities) > 0.01:
+                logger.warning(f'Variable {varname} | {conditionals} has probabilities not summing to 1 '
+                               f'in line {line_no + 1} (sums to {sum(probabilities)})')
+
+            logger.info(f'\t{keys} - {probabilities}')
+            probabilities_lst.append((keys + probabilities))
+
+        yield varname, conditionals, probabilities_lst
+
+
+def bif(bif: str) -> Tuple[pd.DataFrame, List[Tuple[str, str]]]:
+    """
+    Parses a Bayesian Interchange Format (bif) string into a probability table and a set of links
+    """
+    probability_table = pd.DataFrame({'key': [1], 'prob': [1]})
+
+    if parse_network_type(bif) != 'unknown':
+        logger.warning("BIF Parser does not take into account known networks")
+
+    variable_states = dict(parse_variables(bif))
+    edges = []
+
+    for varname, probs in parse_unconditional_probabilities(bif):
+        var_df = pd.DataFrame({varname: variable_states[varname], 'prob': probs})
+        probability_table = join_independent(probability_table, var_df)
+
+    for varname, conditionals, probabilities in parse_conditional_probabilities(bif):
+        cond_df = (pd.DataFrame(probabilities, columns=conditionals + variable_states[varname])
+                   .melt(id_vars=conditionals, var_name=varname, value_name='prob')
+                   .set_index(conditionals)
+                   )
+        probability_table = join_dependent(probability_table, cond_df)
+        edges += [(conditional, varname) for conditional in conditionals]
+
+    return probability_table, edges

--- a/tests/test_bif_parser.py
+++ b/tests/test_bif_parser.py
@@ -1,0 +1,158 @@
+import pandas as pd
+import pytest
+
+from brent import parsers
+from brent.parsers.bif import join_independent, join_dependent, parse_network_type, parse_variables, \
+    parse_unconditional_probabilities, parse_conditional_probabilities
+
+
+@pytest.fixture
+def test_bif():
+    return """network unknown {
+}
+variable A {
+  type discrete [ 2 ] { yes, no };
+}
+variable B {
+  type discrete [ 2 ] { yes, no };
+}
+variable C {
+  type discrete [ 2 ] { yes, no };
+}
+variable D {
+  type discrete [ 2 ] { yes, no };
+}
+probability ( A ) {
+  table 0.01, 0.99;
+}
+probability ( C | B ) {
+  (yes) 0.05, 0.95;
+  (no) 0.01, 0.99;
+}
+probability ( B ) {
+  table 0.5, 0.5;
+}
+probability ( D | B, A ) {
+  (yes, yes) 1.0, 0.0;
+  (no, yes) 1.0, 0.0;
+  (yes, no) 1.0, 0.0;
+  (no, no) 0.0, 1.0;
+}
+"""
+
+
+@pytest.fixture
+def prob_a():
+    return pd.DataFrame({'A': ['true', 'false'], 'prob': [0.5, 0.5]})
+
+
+@pytest.fixture
+def prob_b():
+    return pd.DataFrame({'B': ['true', 'false'], 'prob': [0.5, 0.5]})
+
+
+@pytest.fixture
+def cond_prob_b():
+    return pd.DataFrame({
+        'A': ['true', 'false', 'true', 'false'],
+        'B': ['true', 'true', 'false', 'false'],
+        'prob': [0.3, 0.7, 0.8, 0.2]}).set_index('A')
+
+
+def test_join_independent(prob_a, prob_b):
+    target = pd.DataFrame({
+        'A': ['true', 'true', 'false', 'false'],
+        'B': ['true', 'false', 'true', 'false'],
+        'prob': [0.25, 0.25, 0.25, 0.25]
+    })
+    pd.testing.assert_frame_equal(join_independent(prob_a, prob_b), target)
+
+
+def test_join_independent_input_checks(prob_a, prob_b):
+    with pytest.raises(ValueError):
+        join_independent(prob_a.drop(columns=['prob']), prob_b)
+
+    with pytest.raises(ValueError):
+        join_independent(prob_a, prob_b.drop(columns=['prob']))
+
+
+def test_join_dependent(prob_a, cond_prob_b):
+    target = pd.DataFrame({
+        'A': ['true', 'true', 'false', 'false'],
+        'B': ['true', 'false', 'true', 'false'],
+        'prob': [0.15, 0.4, 0.35, 0.1]
+    })
+    pd.testing.assert_frame_equal(join_dependent(prob_a, cond_prob_b), target)
+
+
+def test_join_dependent_input_checks(prob_a, cond_prob_b):
+    with pytest.raises(ValueError):
+        join_dependent(prob_a.drop(columns=['prob']), cond_prob_b)
+
+    with pytest.raises(ValueError):
+        join_dependent(prob_a, cond_prob_b.drop(columns=['prob']))
+
+    with pytest.raises(ValueError):
+        join_dependent(prob_a.drop(columns=['A']), cond_prob_b)
+
+    with pytest.raises(ValueError):
+        join_dependent(prob_a, cond_prob_b.reset_index())
+
+
+def test_parse(test_bif):
+    probability_df, links = parsers.bif(test_bif)
+
+    target = pd.DataFrame({
+        'A': ['yes', 'yes', 'yes', 'yes', 'no', 'no', 'no', 'no', 'yes', 'yes', 'yes', 'yes', 'no', 'no', 'no', 'no'],
+        'B': ['yes', 'yes', 'yes', 'yes', 'yes', 'yes', 'yes', 'yes', 'no', 'no', 'no', 'no', 'no', 'no', 'no', 'no'],
+        'C': ['yes', 'yes', 'no', 'no', 'yes', 'yes', 'no', 'no', 'yes', 'yes', 'no', 'no', 'yes', 'yes', 'no', 'no'],
+        'D': ['yes', 'no', 'yes', 'no', 'yes', 'no', 'yes', 'no', 'yes', 'no', 'yes', 'no', 'yes', 'no', 'yes', 'no'],
+        'prob': [0.00025, 0.0, 0.00475, 0.0, 0.02475, 0.0, 0.47025, 0.0, 5e-05, 0.0, 0.00495, 0.0, 0.0, 0.00495, 0.0,
+                 0.49005]
+    })
+
+    pd.testing.assert_frame_equal(probability_df, target)
+    target_links = [
+        ('A', 'D'),
+        ('B', 'D'),
+        ('B', 'C'),
+    ]
+    assert sorted(links) == sorted(target_links)
+
+
+def test_parse_network_type(test_bif):
+    assert parse_network_type(test_bif) == 'unknown'
+
+
+def test_parse_variables(test_bif):
+    target = [
+        ('A', ['yes', 'no']),
+        ('B', ['yes', 'no']),
+        ('C', ['yes', 'no']),
+        ('D', ['yes', 'no']),
+    ]
+    assert list(parse_variables(test_bif)) == target
+
+
+def test_parse_unconditional_variables(test_bif):
+    target = [
+        ('A', [0.01, 0.99]),
+        ('B', [0.5, 0.5]),
+    ]
+    assert list(parse_unconditional_probabilities(test_bif)) == target
+
+
+def test_parse_conditional_variables(test_bif):
+    target = [
+        ('C', ['B'], [
+            ['yes', 0.05, 0.95],
+            ['no', 0.01, 0.99]
+        ]),
+        ('D', ['B', 'A'], [
+            ['yes', 'yes', 1.0, 0.0],
+            ['no', 'yes', 1.0, 0.0],
+            ['yes', 'no', 1.0, 0.0],
+            ['no', 'no', 0.0, 1.0]
+        ]),
+    ]
+    assert list(parse_conditional_probabilities(test_bif)) == target

--- a/tests/test_bif_parser.py
+++ b/tests/test_bif_parser.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 
 from brent import parsers
-from brent.parsers.bif import join_independent, join_dependent, parse_network_type, parse_variables, \
+from brent.parsers.bif import parse_network_type, parse_variables, \
     parse_unconditional_probabilities, parse_conditional_probabilities
 
 
@@ -39,64 +39,6 @@ probability ( D | B, A ) {
   (no, no) 0.0, 1.0;
 }
 """
-
-
-@pytest.fixture
-def prob_a():
-    return pd.DataFrame({'A': ['true', 'false'], 'prob': [0.5, 0.5]})
-
-
-@pytest.fixture
-def prob_b():
-    return pd.DataFrame({'B': ['true', 'false'], 'prob': [0.5, 0.5]})
-
-
-@pytest.fixture
-def cond_prob_b():
-    return pd.DataFrame({
-        'A': ['true', 'false', 'true', 'false'],
-        'B': ['true', 'true', 'false', 'false'],
-        'prob': [0.3, 0.7, 0.8, 0.2]}).set_index('A')
-
-
-def test_join_independent(prob_a, prob_b):
-    target = pd.DataFrame({
-        'A': ['true', 'true', 'false', 'false'],
-        'B': ['true', 'false', 'true', 'false'],
-        'prob': [0.25, 0.25, 0.25, 0.25]
-    })
-    pd.testing.assert_frame_equal(join_independent(prob_a, prob_b), target)
-
-
-def test_join_independent_input_checks(prob_a, prob_b):
-    with pytest.raises(ValueError):
-        join_independent(prob_a.drop(columns=['prob']), prob_b)
-
-    with pytest.raises(ValueError):
-        join_independent(prob_a, prob_b.drop(columns=['prob']))
-
-
-def test_join_dependent(prob_a, cond_prob_b):
-    target = pd.DataFrame({
-        'A': ['true', 'true', 'false', 'false'],
-        'B': ['true', 'false', 'true', 'false'],
-        'prob': [0.15, 0.4, 0.35, 0.1]
-    })
-    pd.testing.assert_frame_equal(join_dependent(prob_a, cond_prob_b), target)
-
-
-def test_join_dependent_input_checks(prob_a, cond_prob_b):
-    with pytest.raises(ValueError):
-        join_dependent(prob_a.drop(columns=['prob']), cond_prob_b)
-
-    with pytest.raises(ValueError):
-        join_dependent(prob_a, cond_prob_b.drop(columns=['prob']))
-
-    with pytest.raises(ValueError):
-        join_dependent(prob_a.drop(columns=['A']), cond_prob_b)
-
-    with pytest.raises(ValueError):
-        join_dependent(prob_a, cond_prob_b.reset_index())
 
 
 def test_parse(test_bif):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,6 +1,25 @@
+import pandas as pd
 import pytest
 
-from brent.common import window, normalise, check_node_blocking
+from brent.common import window, normalise, check_node_blocking, join_independent, join_dependent
+
+
+@pytest.fixture
+def prob_a():
+    return pd.DataFrame({'A': ['true', 'false'], 'prob': [0.5, 0.5]})
+
+
+@pytest.fixture
+def prob_b():
+    return pd.DataFrame({'B': ['true', 'false'], 'prob': [0.5, 0.5]})
+
+
+@pytest.fixture
+def cond_prob_b():
+    return pd.DataFrame({
+        'A': ['true', 'false', 'true', 'false'],
+        'B': ['true', 'true', 'false', 'false'],
+        'prob': [0.3, 0.7, 0.8, 0.2]}).set_index('A')
 
 
 def test_window():
@@ -28,3 +47,43 @@ def test_check_node_blocking_split():
 def test_check_node_blocking_collider():
     assert check_node_blocking(arrow_before='->', name='a', arrow_after='<-')
     assert not check_node_blocking(arrow_before='->', name='given_a', arrow_after='<-')
+
+
+def test_join_independent(prob_a, prob_b):
+    target = pd.DataFrame({
+        'A': ['true', 'true', 'false', 'false'],
+        'B': ['true', 'false', 'true', 'false'],
+        'prob': [0.25, 0.25, 0.25, 0.25]
+    })
+    pd.testing.assert_frame_equal(join_independent(prob_a, prob_b), target)
+
+
+def test_join_independent_input_checks(prob_a, prob_b):
+    with pytest.raises(ValueError):
+        join_independent(prob_a.drop(columns=['prob']), prob_b)
+
+    with pytest.raises(ValueError):
+        join_independent(prob_a, prob_b.drop(columns=['prob']))
+
+
+def test_join_dependent(prob_a, cond_prob_b):
+    target = pd.DataFrame({
+        'A': ['true', 'true', 'false', 'false'],
+        'B': ['true', 'false', 'true', 'false'],
+        'prob': [0.15, 0.4, 0.35, 0.1]
+    })
+    pd.testing.assert_frame_equal(join_dependent(prob_a, cond_prob_b), target)
+
+
+def test_join_dependent_input_checks(prob_a, cond_prob_b):
+    with pytest.raises(ValueError):
+        join_dependent(prob_a.drop(columns=['prob']), cond_prob_b)
+
+    with pytest.raises(ValueError):
+        join_dependent(prob_a, cond_prob_b.drop(columns=['prob']))
+
+    with pytest.raises(ValueError):
+        join_dependent(prob_a.drop(columns=['A']), cond_prob_b)
+
+    with pytest.raises(ValueError):
+        join_dependent(prob_a, cond_prob_b.reset_index())


### PR DESCRIPTION
This would aid in interoperability with the broader ecosystem as well as help in adding examples from http://www.bnlearn.com/bnrepository/#alarm

It does requires a DAG constructor from probability dataframes rather than observation dataframes

future usage example:
```
from brent import parsers
probability_df, edges = parsers.bif(test_bif)
DAG.from_prob_dataframe(probability_df).add_edges(edges)
```